### PR TITLE
Add execute-task to execute task and discard return value

### DIFF
--- a/src/kernel/core.lisp
+++ b/src/kernel/core.lisp
@@ -502,13 +502,16 @@ Calling `broadcast-task' from inside a worker is an error."
     (repeat worker-count (push-queue t to-workers))
     (map-into (make-array worker-count) (lambda () (receive-result channel)))))
 
-(defun execute-task (fn &rest args)
+(defun submit-bare-task (fn &rest args)
   "Schedule a task to be run with the current value of `*kernel*'.
 
 The result of the function call is discarded."
   (declare #.*normal-optimize*)
   (submit-raw-task (make-task (task-lambda (apply fn args)))
                    *kernel*))
+
+(defmacro bare-task (&body body)
+  `(submit-bare-task (lambda () ,@body)))
 
 (defun track-exit ()
   (setf *lisp-exiting-p* t))

--- a/src/kernel/core.lisp
+++ b/src/kernel/core.lisp
@@ -502,6 +502,14 @@ Calling `broadcast-task' from inside a worker is an error."
     (repeat worker-count (push-queue t to-workers))
     (map-into (make-array worker-count) (lambda () (receive-result channel)))))
 
+(defun execute-task (fn &rest args)
+  "Schedule a task to be run with the current value of `*kernel*'.
+
+The result of the function call is discarded."
+  (declare #.*normal-optimize*)
+  (submit-raw-task (make-task (task-lambda (apply fn args)))
+                   *kernel*))
+
 (defun track-exit ()
   (setf *lisp-exiting-p* t))
 

--- a/src/kernel/package.lisp
+++ b/src/kernel/package.lisp
@@ -51,6 +51,7 @@
   (:export #:make-channel
            #:submit-task
            #:broadcast-task
+           #:execute-task
            #:submit-timeout
            #:cancel-timeout
            #:receive-result

--- a/src/kernel/package.lisp
+++ b/src/kernel/package.lisp
@@ -51,7 +51,8 @@
   (:export #:make-channel
            #:submit-task
            #:broadcast-task
-           #:execute-task
+           #:submit-bare-task
+           #:bare-task
            #:submit-timeout
            #:cancel-timeout
            #:receive-result

--- a/test/kernel-test.lisp
+++ b/test/kernel-test.lisp
@@ -697,7 +697,15 @@
       (signals error
         (receive-result channel)))
     (signals error
-      (broadcast-task (lambda () (broadcast-task (lambda ())))))))
+             (broadcast-task (lambda () (broadcast-task (lambda ())))))))
+
+(full-test execute-task-test
+  (let ((queue (make-queue :fixed-capacity 1)))
+    (execute-task (lambda (v)
+                    (sleep 0.5)
+                    (push-queue v queue)) t)
+    (is (null (try-pop-queue queue :timeout 0)))
+    (is (try-pop-queue queue :timeout 1))))
 
 (full-test worker-index-test
   (is (null (kernel-worker-index)))

--- a/test/kernel-test.lisp
+++ b/test/kernel-test.lisp
@@ -699,11 +699,11 @@
     (signals error
              (broadcast-task (lambda () (broadcast-task (lambda ())))))))
 
-(full-test execute-task-test
+(full-test bare-task-test
   (let ((queue (make-queue :fixed-capacity 1)))
-    (execute-task (lambda (v)
-                    (sleep 0.5)
-                    (push-queue v queue)) t)
+    (submit-bare-task (lambda (v)
+                        (sleep 0.5)
+                        (push-queue v queue)) t)
     (is (null (try-pop-queue queue :timeout 0)))
     (is (try-pop-queue queue :timeout 1))))
 


### PR DESCRIPTION
This allows you to schedule a task without the overhead of needing to
keep track of the return value.
