### PR TITLE
Append *default-special-bindings* set from elsewhere on thread creation

### DIFF
--- a/src/thread-util.lisp
+++ b/src/thread-util.lisp
@@ -157,7 +157,7 @@
   `(progn ,@body))
 
 (defmacro with-thread ((&key bindings name) &body body)
-  `(let ((*default-special-bindings* ,bindings))
+  `(let ((*default-special-bindings* (append ,bindings *default-special-bindings*)))
      (make-thread (lambda ()
                     (with-abort-restart
                       ,@body))


### PR DESCRIPTION
Follow up on [this discussion](https://github.com/cosmos72/stmx/issues/26) in `stmx` repository.
We found out that `*default-special-bindings*` special variable gets overwritten by kernel bindings in `with-thread` macro on thread creation.

The patch solves this, appending the possibly existing values to kernel bindings. Fixes the interoperability issue with `stmx` and possibly other libraries, relying on those thread bindings.