### PR TITLE
Add utility to ensure that a kernel with arbitrary workers exist.

### DIFF
--- a/src/kernel/core.lisp
+++ b/src/kernel/core.lisp
@@ -275,6 +275,16 @@ MAKE-KERNEL and STORE-VALUE restarts. Returns `*kernel*'."
           (check-type value kernel)
           (setf *kernel* value)))))
 
+(defun ensure-kernel (worker-count &rest other-keys)
+  "Return `*kernel*', a kernel instance featuring WORKER-COUNT."
+  ;; Notice that when *kernel* exists with 2 workers, then calling:
+  ;; (ensure-kernel 2 :name "a-different-name-from-the-one-set-in-*kernel*")
+  ;; has no effect since the number of workers matches.
+  (if (and *kernel*
+           (eq (length (workers *kernel*)) worker-count))
+      *kernel*
+      (setf *kernel* (apply #'make-kernel worker-count other-keys))))
+
 (defmacro define-worker-info-reader (name slot &optional (result slot))
   `(defun ,name ()
      ,(format nil "Return the ~a passed to `make-kernel'."

--- a/src/kernel/package.lisp
+++ b/src/kernel/package.lisp
@@ -42,6 +42,7 @@
         #+lparallel.with-stealing-scheduler #:lparallel.spin-queue)
   (:export #:make-kernel
            #:check-kernel
+           #:ensure-kernel
            #:end-kernel
            #:kernel-worker-count
            #:kernel-worker-index


### PR DESCRIPTION
This is a handy utility that complements `check-kernel`.